### PR TITLE
Linear legends with custom label formats

### DIFF
--- a/src/legend.js
+++ b/src/legend.js
@@ -29,12 +29,14 @@ d3_linearLegend: function (scale, cells, labelFormat) {
     i = 0;
 
     for (; i < cells; i++){
-      data.push(labelFormat(domain[0] + i*increment));
+      data.push(domain[0] + i*increment);
     }
   }
 
+  var labels = data.map(labelFormat);
+
   return {data: data,
-          labels: data,
+          labels: labels,
           feature: function(d){ return scale(d); }};
 },
 


### PR DESCRIPTION
Linear legends weren't working for me if I used a custom label format.
e.g., 

```
legend.labelFormat(d3.format('%'));
```

would produce labels that used percentages, but the coloured boxes would be the wrong colours.

This patch fixes the problem for me.
