### PR TITLE
Add ascending option

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -16,12 +16,13 @@ module.exports = function(){
     labelAlign = "middle",
     labelDelimiter = "to",
     orient = "vertical",
+    ascending = false,
     path,
     legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
 
     function legend(svg){
 
-      var type = helper.d3_calcType(scale, cells, labels, labelFormat, labelDelimiter);
+      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter);
 
       var cell = svg.selectAll(".cell").data(type.data),
         cellEnter = cell.enter().append("g", ".cell").attr("class", "cell").style("opacity", 1e-6);
@@ -169,6 +170,12 @@ module.exports = function(){
     if (_ == "horizontal" || _ == "vertical") {
       orient = _;
     }
+    return legend;
+  };
+
+  legend.ascending = function(_) {
+    if (!arguments.length) return legend;
+    ascending = !!_;
     return legend;
   };
 

--- a/src/legend.js
+++ b/src/legend.js
@@ -88,12 +88,17 @@ d3_addText: function (svg, enter, labels){
   svg.selectAll("g.cell text").data(labels).text(this.d3_identity);
 },
 
-d3_calcType: function (scale, cells, labels, labelFormat, labelDelimiter){
+d3_calcType: function (scale, ascending, cells, labels, labelFormat, labelDelimiter){
   var type = scale.ticks ?
           this.d3_linearLegend(scale, cells, labelFormat) : scale.invertExtent ?
           this.d3_quantLegend(scale, labelFormat, labelDelimiter) : this.d3_ordinalLegend(scale);
 
   type.labels = this.d3_mergeLabels(type.labels, labels);
+
+  if (ascending) {
+    type.labels.reverse();
+    type.data.reverse();
+  }
 
   return type;
 },

--- a/src/size.js
+++ b/src/size.js
@@ -14,12 +14,13 @@ module.exports =  function(){
     labelAlign = "middle",
     labelDelimiter = "to",
     orient = "vertical",
+    ascending = false,
     path,
     legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
 
     function legend(svg){
 
-      var type = helper.d3_calcType(scale, cells, labels, labelFormat, labelDelimiter);
+      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter);
 
       var cell = svg.selectAll(".cell").data(type.data),
         cellEnter = cell.enter().append("g", ".cell").attr("class", "cell").style("opacity", 1e-6);
@@ -164,6 +165,12 @@ module.exports =  function(){
     if (_ == "horizontal" || _ == "vertical") {
       orient = _;
     }
+    return legend;
+  };
+
+  legend.ascending = function(_) {
+    if (!arguments.length) return legend;
+    ascending = !!_;
     return legend;
   };
 

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -16,11 +16,12 @@ module.exports = function(){
     labelOffset = 10,
     labelDelimiter = "to",
     orient = "vertical",
+    ascending = false,
     legendDispatcher = d3.dispatch("cellover", "cellout", "cellclick");
 
     function legend(svg){
 
-      var type = helper.d3_calcType(scale, cells, labels, labelFormat, labelDelimiter);
+      var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter);
 
       var cell = svg.selectAll(".cell").data(type.data),
         cellEnter = cell.enter().append("g", ".cell").attr("class", "cell").style("opacity", 1e-6);
@@ -123,6 +124,12 @@ module.exports = function(){
     if (_ == "horizontal" || _ == "vertical") {
       orient = _;
     }
+    return legend;
+  };
+
+  legend.ascending = function(_) {
+    if (!arguments.length) return legend;
+    ascending = !!_;
     return legend;
   };
 


### PR DESCRIPTION
Adds an optional `ascending` option to any legend to draw the legend items in a reverse order, from top to bottom.

> legend.ascending(true);

Default is `false` so it won’t affect any existing code.
