### PR TITLE
Ensure legend construction is idempotent

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -25,7 +25,9 @@ module.exports = function(){
     function legend(svg){
 
       var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-        legendG = svg.append('g').attr('class', classPrefix + 'legendCells');
+        legendG = svg.selectAll('g').data([scale]);
+
+      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
 
 
       var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
@@ -202,4 +204,3 @@ module.exports = function(){
   return legend;
 
 };
-

--- a/src/size.js
+++ b/src/size.js
@@ -23,7 +23,9 @@ module.exports =  function(){
     function legend(svg){
 
       var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-        legendG = svg.append('g').attr('class', classPrefix + 'legendCells');
+        legendG = svg.selectAll('g').data([scale]);
+
+      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
 
 
       var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
@@ -195,4 +197,3 @@ module.exports =  function(){
   return legend;
 
 };
-

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -24,7 +24,9 @@ module.exports = function(){
     function legend(svg){
 
       var type = helper.d3_calcType(scale, ascending, cells, labels, labelFormat, labelDelimiter),
-        legendG = svg.append('g').attr('class', classPrefix + 'legendCells');
+        legendG = svg.selectAll('g').data([scale]);
+
+      legendG.enter().append('g').attr('class', classPrefix + 'legendCells');
 
       var cell = legendG.selectAll("." + classPrefix + "cell").data(type.data),
         cellEnter = cell.enter().append("g", ".cell").attr("class", classPrefix + "cell").style("opacity", 1e-6);
@@ -154,4 +156,3 @@ module.exports = function(){
   return legend;
 
 };
-


### PR DESCRIPTION
Thanks for this amazing component - really well designed. I love the idea of constructing the legend directly from a scale.

The reason I am looking for a legend is because I am currently involved with d3fc, where we are trying to build a more component-based charting library. I was about to build my own svg legend when I stumbled upon your project. You can see an example of the d3fc approach here:

http://d3fc.io/examples/scatter/

Anyhow, I'd love to integrate your legend with out charting components.

One issue I did spot is that your legend is not idempotent. If you call it multiple times on a selection, the legend is duplicated:

```
svg.select(".legendSymbol")
  .call(legend);

svg.select(".legendSymbol")
  .call(legend);
```

If you try the same with d3's axis, it is only rendered once, with subsequent 'calls' resulting the the existing axis being updated.

This PR modified the legend construction to use a data-join so that it is idempotent.

Thanks, Colin E.
