### PR TITLE
Only package code for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.5.0",
   "description": "A legend component for d3. Given a d3.scale it can create either a color legend, size legend, or symbol legend.",
   "main": "index.js",
+  "files": [
+    "src",
+    "index.js",
+    "d3-legend.*"
+  ],
   "keywords": [
     "d3",
     "legend"


### PR DESCRIPTION
Hello.  Thank you for this module!

Currently when someone installs d3-svg-legend as a dependency via npm the entire repo is downloaded to their filesystem... including docs and tests. With this change only package.json, LICENSE, README.md and the JS files will be downloaded. See here: https://docs.npmjs.com/files/package.json#files. You can test what files get packaged by executing npm pack.
