### PR TITLE
Fixed 'unexpected token' error for node

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var d3 = require('d3'),
-d3.legend = require('./no-extend')
+var d3 = require('d3');
+
+d3.legend = require('./no-extend');
 
 module.exports = d3;


### PR DESCRIPTION
I fixed an error with loading the module via the "require('d3-svg-legend)' method which fails due to the d3 require statement not being separated from the d3.legend statement.

An example of this error can be found by clicking on 'Test d3-svg-legend in your browser.' link on the npm page for version 1.7.0.

https://tonicdev.com/56a011cac4e01c0d005a3e96/56a011cac4e01c0d005a3e97
