### PR TITLE
Enable usage with browserify

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -1,3 +1,4 @@
+var d3 = require('d3');
 var helper = require('./legend');
 
 module.exports = function(){

--- a/src/legend.js
+++ b/src/legend.js
@@ -1,3 +1,5 @@
+var d3 = require('d3');
+
 module.exports = {
 
   d3_identity: function (d) {

--- a/src/size.js
+++ b/src/size.js
@@ -1,3 +1,4 @@
+var d3 = require('d3');
 var helper = require('./legend');
 
 module.exports =  function(){

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -1,3 +1,4 @@
+var d3 = require('d3');
 var helper = require('./legend');
 
 module.exports = function(){

--- a/src/web.js
+++ b/src/web.js
@@ -1,3 +1,5 @@
+var d3 = require('d3');
+
 d3.legend = {
   color: require('./color'),
   size: require('./size'),


### PR DESCRIPTION
Hello,

We use _browserify_ (http://browserify.org/) in our project to build our browser scripts. The current implementation of _d3-legend_ requires the _d3_ module to be imported globally before importing the legend module. With _browserify_ all modules need to be imported in local scopes similar to _Node.js_.
This pull requests adds the missing imports to enable building with _browserify_.

Best regards
Marcel
