### PR TITLE
Add d3-module keyword.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "keywords": [
     "d3",
+    "d3-module",
     "legend"
   ],
   "directories": {


### PR DESCRIPTION
Since this excellent module now supports D3 4.x+, it’d be great to add the d3-module keyword so that it shows up alongside the other [D3 modules on npm](https://www.npmjs.com/browse/keyword/d3-module).
