### PR TITLE
add merge cell selection to apply legend changes to all cells (including already existing)

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -156,7 +156,7 @@ export default function color(){
 
   legend.labelFormat = function(_) {
     if (!arguments.length) return labelFormat;
-    labelFormat = _;
+    labelFormat = typeof(_) === 'string' ? format(_) : _;
     return legend;
   };
 

--- a/src/color.js
+++ b/src/color.js
@@ -46,10 +46,14 @@ export default function color(){
 
       helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, path);
 
+
       helper.d3_addText( svg, cellEnter, type.labels, classPrefix)
+      
+      // we need to merge the selection, otherwise changes in the legend (e.g. change of orientation) are applied only to the new cells and not the existing ones.
+      cell = cellEnter.merge(cell);
 
       // sets placement
-      var text = cellEnter.selectAll("text"),
+      var text = cell.selectAll("text"),
         shapeSize = shapes.nodes().map( function(d){ return d.getBBox(); });
 
       //sets scale
@@ -80,7 +84,7 @@ export default function color(){
           "," + (shapeSize[i].height + shapeSize[i].y + labelOffset + 8) + ")"; };
       }
 
-      helper.d3_placement(orient, cellEnter, cellTrans, text, textTrans, labelAlign);
+      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
       helper.d3_title(svg, title, classPrefix);
 
       cell.transition().style("opacity", 1);

--- a/src/size.js
+++ b/src/size.js
@@ -157,7 +157,7 @@ export default function size(){
 
   legend.labelFormat = function(_) {
     if (!arguments.length) return labelFormat;
-    labelFormat = _;
+    labelFormat = typeof(_) === 'string' ? format(_) : _;
     return legend;
   };
 

--- a/src/size.js
+++ b/src/size.js
@@ -53,8 +53,11 @@ export default function size(){
 
       helper.d3_addText( svg, cellEnter, type.labels, classPrefix)
 
+      // we need to merge the selection, otherwise changes in the legend (e.g. change of orientation) are applied only to the new cells and not the existing ones.
+      cell = cellEnter.merge(cell);
+
       //sets placement
-      var text = cellEnter.selectAll("text"),
+      var text = cell.selectAll("text"),
         shapeSize = shapes.nodes().map(
           function(d, i){
             var bbox = d.getBBox()
@@ -95,7 +98,7 @@ export default function size(){
               (maxH + labelOffset ) + ")"; };
       }
 
-      helper.d3_placement(orient, cellEnter, cellTrans, text, textTrans, labelAlign);
+      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
       helper.d3_title(svg, title, classPrefix);
 
       cell.transition().style("opacity", 1);

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -48,8 +48,11 @@ export default function symbol(){
       helper.d3_drawShapes(shape, shapes, shapeHeight, shapeWidth, shapeRadius, type.feature);
       helper.d3_addText( svg, cellEnter, type.labels, classPrefix)
 
+      // we need to merge the selection, otherwise changes in the legend (e.g. change of orientation) are applied only to the new cells and not the existing ones.
+      cell = cellEnter.merge(cell);
+
       // sets placement
-      var text = cellEnter.selectAll("text"),
+      var text = cell.selectAll("text"),
         shapeSize = shapes.nodes().map( function(d){ return d.getBBox(); });
 
       var maxH = max(shapeSize, function(d){ return d.height; }),
@@ -71,7 +74,7 @@ export default function symbol(){
               (maxH + labelOffset ) + ")"; };
       }
 
-      helper.d3_placement(orient, cellEnter, cellTrans, text, textTrans, labelAlign);
+      helper.d3_placement(orient, cell, cellTrans, text, textTrans, labelAlign);
       helper.d3_title(svg, title, classPrefix);
       cell.transition().style("opacity", 1);
 

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -117,7 +117,7 @@ export default function symbol(){
 
   legend.labelFormat = function(_) {
     if (!arguments.length) return labelFormat;
-    labelFormat = _;
+    labelFormat = typeof(_) === 'string' ? format(_) : _;
     return legend;
   };
 


### PR DESCRIPTION
Thanks a lot for this plugin, very useful !

[Selection.append no longer merges entering nodes into the update selection](https://github.com/d3/d3/blob/master/CHANGES.md#selections-d3-selection).  Without merging the entering nodes with the existing ones,  a change in the legend config (e.g. setting a different orientation) will have no effect if we call the legend again (against the same main group selection). 

This PR. makes sure selections are merged and hence config changes are properly applied.
