### PR TITLE
Fixed spacing of horizontal color legend when labels are wider than shape

### DIFF
--- a/src/color.js
+++ b/src/color.js
@@ -62,7 +62,7 @@ export default function color(){
           if (orient === "horizontal" && textSize[i].width > d.width) {
               return textSize[i].width
           } else {
-              d.width;
+              return d.width;
           }
         });
 

--- a/src/legend.js
+++ b/src/legend.js
@@ -117,12 +117,13 @@ export default {
     return mirror;
   },
 
-  d3_placement: function (orient, cell, cellTrans, text, textTrans, labelAlign) {
+  d3_placement: function (orient, cell, cellTrans, text, textTrans, labelAlign, shape, shapeTrans) {
     cell.attr("transform", cellTrans);
     text.attr("transform", textTrans);
     if (orient === "horizontal"){
       text.style("text-anchor", labelAlign);
     }
+    if (shape && shapeTrans) shape.attr("transform", shapeTrans);
   },
 
   d3_addEvents: function(cells, dispatcher){


### PR DESCRIPTION
@susielu I've updated the color legend to correctly space out the legend items based on the the text labels. This is done by determining if the label or shape is wider for each legend item and then adjusting the shape and text based on the labelAlign property.

I did not updated the symbol or size legends because I wanted to see if this is something you'd want to include in the library and if it was applicable to those legends. This was something I needed that currently only applies to the color legend. Let me know if you need/want me to update the other legends.
