### PR TITLE
<fix> Fixed last item in array being skipped for custom labels due to…

### DIFF
--- a/src/legend.js
+++ b/src/legend.js
@@ -10,7 +10,7 @@ export default {
         if(labels.length === 0) return gen;
 
         let i = labels.length;
-        for (; i < gen.length; i++) {
+        for (; i <= gen.length; i++) {
           labels.push(gen[i]);
         }
         return labels;


### PR DESCRIPTION
When providing an array of custom labels, the last item will be skipped due to the Array.length starting at 1. This fixes that issue. 
