### PR TITLE
The example in the readme doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ svg.append("g")
   .attr("class", "legendQuant")
   .attr("transform", "translate(20,20)");
 
-var colorLegend = legendColor()
+var colorLegend = d3.legendColor()
     .labelFormat(d3.format(".2f"))
     .useClass(true)
     .scale(quantize);


### PR DESCRIPTION
I think you are missing a `d3.`there. This is important since this example is the first thing we lazy users and lurkers of your wonderful work copy and paste to use your lib. Thanks for the hard work!